### PR TITLE
PAM-3715 Legger til aria/WCAG-attributter i typeahead for å gjøre den…

### DIFF
--- a/src/Seksjon/Arbeidserfaring.elm
+++ b/src/Seksjon/Arbeidserfaring.elm
@@ -1724,8 +1724,7 @@ viewTypeaheadRegistrerYrke : TypeaheadState Yrke -> Html Msg
 viewTypeaheadRegistrerYrke typeaheadState =
     typeaheadState
         |> TypeaheadState.value
-        |> Typeahead.typeahead { label = "Hvilken stilling/yrke har du?", onInput = BrukerOppdatererYrke, onTypeaheadChange = BrukerTrykkerTypeaheadTast }
-        |> Typeahead.withInputId (inputIdTilString YrkeTypeaheadId)
+        |> Typeahead.typeahead { label = "Hvilken stilling/yrke har du?", onInput = BrukerOppdatererYrke, onTypeaheadChange = BrukerTrykkerTypeaheadTast, inputId = inputIdTilString YrkeTypeaheadId }
         |> Typeahead.withSuggestions (typeaheadStateSuggestionsTilViewSuggestionRegistrerYrke typeaheadState)
         |> Typeahead.toHtml
 
@@ -1753,7 +1752,7 @@ viewTypeaheadOppsummering : TypeaheadState Yrke -> Html Msg
 viewTypeaheadOppsummering typeaheadState =
     typeaheadState
         |> TypeaheadState.value
-        |> Typeahead.typeahead { label = "Stilling/yrke", onInput = YrkeRedigeringsfeltEndret, onTypeaheadChange = BrukerTrykkerTypeaheadTastIOppsummering }
+        |> Typeahead.typeahead { label = "Stilling/yrke", onInput = YrkeRedigeringsfeltEndret, onTypeaheadChange = BrukerTrykkerTypeaheadTastIOppsummering, inputId = inputIdTilString YrkeTypeaheadId }
         |> Typeahead.withSuggestions (typeaheadStateSuggestionsTilViewSuggestionOppsummering typeaheadState)
         |> Typeahead.toHtml
 

--- a/src/Seksjon/Fagdokumentasjon.elm
+++ b/src/Seksjon/Fagdokumentasjon.elm
@@ -862,9 +862,8 @@ viewTypeahead : TypeaheadState Konsept -> FagdokumentasjonType -> Html Msg
 viewTypeahead typeaheadState fagdokumentasjonType =
     typeaheadState
         |> TypeaheadState.value
-        |> Typeahead.typeahead { label = typeaheadLabel fagdokumentasjonType, onInput = BrukerOppdatererFagdokumentasjon, onTypeaheadChange = BrukerTrykkerTypeaheadTast }
+        |> Typeahead.typeahead { label = typeaheadLabel fagdokumentasjonType, onInput = BrukerOppdatererFagdokumentasjon, onTypeaheadChange = BrukerTrykkerTypeaheadTast, inputId = inputIdTilString RegistrerKonseptInput }
         |> Typeahead.withSuggestions (typeaheadStateSuggestionsTilViewSuggestion typeaheadState)
-        |> Typeahead.withInputId (inputIdTilString RegistrerKonseptInput)
         |> Typeahead.toHtml
 
 

--- a/src/Seksjon/Sertifikat.elm
+++ b/src/Seksjon/Sertifikat.elm
@@ -1022,8 +1022,7 @@ viewTypeaheadSertifikatFelt : TypeaheadState SertifikatTypeahead -> Html Msg
 viewTypeaheadSertifikatFelt typeaheadState =
     typeaheadState
         |> TypeaheadState.value
-        |> Typeahead.typeahead { label = "Sertifisering eller sertifikat", onInput = VilOppdatereSertifikatFelt, onTypeaheadChange = TrykkerTypeaheadTast }
-        |> Typeahead.withInputId (inputIdTilString SertifikatTypeaheadId)
+        |> Typeahead.typeahead { label = "Sertifisering eller sertifikat", onInput = VilOppdatereSertifikatFelt, onTypeaheadChange = TrykkerTypeaheadTast, inputId = inputIdTilString SertifikatTypeaheadId }
         |> Typeahead.withSuggestions (typeaheadStateSuggestionsTilViewSertifikatFelt typeaheadState)
         |> Typeahead.toHtml
 
@@ -1191,9 +1190,8 @@ viewTypeahead : TypeaheadState SertifikatTypeahead -> Html Msg
 viewTypeahead typeaheadState =
     typeaheadState
         |> TypeaheadState.value
-        |> Typeahead.typeahead { label = "Sertifisering eller sertifikat", onInput = VilOppdatereSertifikatFelt, onTypeaheadChange = TrykkerTypeaheadTast }
+        |> Typeahead.typeahead { label = "Sertifisering eller sertifikat", onInput = VilOppdatereSertifikatFelt, onTypeaheadChange = TrykkerTypeaheadTast, inputId = inputIdTilString SertifikatTypeaheadId }
         |> Typeahead.withSuggestions (typeaheadStateSuggestionsTilViewSuggestion typeaheadState)
-        |> Typeahead.withInputId (inputIdTilString SertifikatTypeaheadId)
         |> Typeahead.toHtml
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nb">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
… mulig å bruke for skjermlesere

Baserer attributtene på typeaheaden i kandidatsøket, da denne har bra accessibility i følge David Hole. Men legger ikke til aria-expanded og aria-haspopup, selv om disse er i kandidatsøket, fordi det ikke virker som om det er riktig å bruke dem i en typeahead

Løser kun typeahead-delen av denne: https://jira.adeo.no/browse/PAM-3715