### PR TITLE
PAM-3760: Validerer beskrivelse

### DIFF
--- a/src/AnnenErfaring/Seksjon.elm
+++ b/src/AnnenErfaring/Seksjon.elm
@@ -34,6 +34,7 @@ import MeldingsLogg exposing (FerdigAnimertMeldingsLogg, FerdigAnimertStatus(..)
 import Process
 import SamtaleAnimasjon
 import Task
+import ValideringUtils as Validering
 
 
 
@@ -117,6 +118,10 @@ type alias TilDatoInfo =
     , tilÅr : String
     , tillatÅViseFeilmeldingÅr : Bool
     }
+
+
+maxLengthBeskrivelse =
+    2000
 
 
 rolleTilBeskrivelse : String -> BeskrivelseInfo
@@ -269,7 +274,7 @@ update msg (Model model) =
         VilRegistrereBeskrivelse ->
             case model.aktivSamtale of
                 RegistrerBeskrivelse input ->
-                    case Skjema.feilmeldingBeskrivelse input.beskrivelse of
+                    case Validering.feilmeldingMaxAntallTegn input.beskrivelse maxLengthBeskrivelse of
                         Nothing ->
                             ( input
                                 |> SpørOmBrukerVilLeggeInnTidsperiode
@@ -986,7 +991,7 @@ viewBrukerInput (Model model) =
                     Containers.inputMedGåVidereKnapp VilRegistrereBeskrivelse
                         [ info.beskrivelse
                             |> Textarea.textarea { label = "Beskriv oppgavene dine", msg = OppdatererBeskrivelse }
-                            |> Textarea.withMaybeFeilmelding (Skjema.feilmeldingBeskrivelse info.beskrivelse)
+                            |> Textarea.withMaybeFeilmelding (Validering.feilmeldingMaxAntallTegn info.beskrivelse maxLengthBeskrivelse)
                             |> Textarea.withId (inputIdTilString BeskrivelseId)
                             |> Textarea.toHtml
                         ]
@@ -1064,7 +1069,7 @@ viewBrukerInput (Model model) =
                         , skjema
                             |> Skjema.innholdTekstFelt Beskrivelse
                             |> Textarea.textarea { label = "Beskrivelse", msg = Tekst Beskrivelse >> SkjemaEndret }
-                            |> Textarea.withMaybeFeilmelding (Skjema.innholdTekstFelt Beskrivelse skjema |> Skjema.feilmeldingBeskrivelse)
+                            |> Textarea.withMaybeFeilmelding (Validering.feilmeldingMaxAntallTegn (Skjema.innholdTekstFelt Beskrivelse skjema) maxLengthBeskrivelse)
                             |> Textarea.toHtml
                         , skjema
                             |> Skjema.harDatoer

--- a/src/AnnenErfaring/Seksjon.elm
+++ b/src/AnnenErfaring/Seksjon.elm
@@ -34,7 +34,7 @@ import MeldingsLogg exposing (FerdigAnimertMeldingsLogg, FerdigAnimertStatus(..)
 import Process
 import SamtaleAnimasjon
 import Task
-import ValideringUtils as Validering
+import Validering
 
 
 

--- a/src/AnnenErfaring/Skjema.elm
+++ b/src/AnnenErfaring/Skjema.elm
@@ -3,7 +3,6 @@ module AnnenErfaring.Skjema exposing
     , Felt(..)
     , ValidertAnnenErfaringSkjema
     , encode
-    , feilmeldingBeskrivelse
     , feilmeldingFraMåned
     , feilmeldingFraÅr
     , feilmeldingRolle
@@ -35,6 +34,7 @@ module AnnenErfaring.Skjema exposing
 
 import Dato exposing (DatoPeriode(..), Måned(..), TilDato(..), År)
 import Json.Encode
+import ValideringUtils as Validering
 
 
 type AnnenErfaringSkjema
@@ -238,20 +238,6 @@ feilmeldingRolleHvisSynlig (UvalidertSkjema skjema) =
         Nothing
 
 
-feilmeldingBeskrivelse : String -> Maybe String
-feilmeldingBeskrivelse innhold =
-    if String.length innhold <= 2000 then
-        Nothing
-
-    else
-        let
-            tallTekst =
-                (String.length innhold - 2000)
-                    |> String.fromInt
-        in
-        Just ("Du har " ++ tallTekst ++ " tegn for mye")
-
-
 feilmeldingFraMåned : AnnenErfaringSkjema -> Maybe String
 feilmeldingFraMåned (UvalidertSkjema skjema) =
     if skjema.harDatoer && skjema.tillatÅViseFeilmeldingPeriode then
@@ -326,7 +312,7 @@ valider (UvalidertSkjema info) =
     if feilmeldingRolle info.rolle /= Nothing then
         Nothing
 
-    else if feilmeldingBeskrivelse info.beskrivelse /= Nothing then
+    else if Validering.feilmeldingMaxAntallTegn info.beskrivelse 2000 /= Nothing then
         Nothing
 
     else

--- a/src/AnnenErfaring/Skjema.elm
+++ b/src/AnnenErfaring/Skjema.elm
@@ -34,7 +34,7 @@ module AnnenErfaring.Skjema exposing
 
 import Dato exposing (DatoPeriode(..), Måned(..), TilDato(..), År)
 import Json.Encode
-import ValideringUtils as Validering
+import Validering
 
 
 type AnnenErfaringSkjema

--- a/src/Arbeidserfaring/Seksjon.elm
+++ b/src/Arbeidserfaring/Seksjon.elm
@@ -37,7 +37,7 @@ import Process
 import SamtaleAnimasjon
 import Task
 import Typeahead.Typeahead as Typeahead exposing (GetSuggestionStatus(..), InputStatus(..))
-import ValideringUtils as Validering
+import Validering
 import Yrke exposing (Yrke)
 
 

--- a/src/Arbeidserfaring/Skjema.elm
+++ b/src/Arbeidserfaring/Skjema.elm
@@ -33,7 +33,7 @@ module Arbeidserfaring.Skjema exposing
 import Cv.Arbeidserfaring as Arbeidserfaring exposing (Arbeidserfaring)
 import Dato exposing (Måned(..), TilDato(..), År)
 import Json.Encode
-import ValideringUtils as Validering
+import Validering
 import Yrke exposing (Yrke)
 
 

--- a/src/Arbeidserfaring/Skjema.elm
+++ b/src/Arbeidserfaring/Skjema.elm
@@ -33,6 +33,7 @@ module Arbeidserfaring.Skjema exposing
 import Cv.Arbeidserfaring as Arbeidserfaring exposing (Arbeidserfaring)
 import Dato exposing (Måned(..), TilDato(..), År)
 import Json.Encode
+import ValideringUtils as Validering
 import Yrke exposing (Yrke)
 
 
@@ -323,23 +324,27 @@ valider : ArbeidserfaringSkjema -> Maybe ValidertArbeidserfaringSkjema
 valider (ArbeidserfaringSkjema info) =
     -- TODO: Hvorfor sjekker man om Yrke.label er tom streng?
     --            if Yrke.label yrkefelt /= "" then
-    Maybe.map3
-        (\yrke_ tilDato fraÅr_ ->
-            ValidertArbeidserfaringSkjema
-                { yrke = yrke_
-                , jobbTittel = info.jobbTittel
-                , bedriftNavn = info.bedriftsnavn
-                , lokasjon = info.sted
-                , arbeidsoppgaver = info.arbeidsoppgaver
-                , fraMåned = info.fraMåned
-                , fraÅr = fraÅr_
-                , tilDato = tilDato
-                , id = info.id
-                }
-        )
-        info.yrke
-        (validerTilDato info.nåværende info.tilMåned info.tilÅr)
-        (Dato.stringTilÅr info.fraÅr)
+    if Validering.feilmeldingMaxAntallTegn info.arbeidsoppgaver 2000 /= Nothing then
+        Nothing
+
+    else
+        Maybe.map3
+            (\yrke_ tilDato fraÅr_ ->
+                ValidertArbeidserfaringSkjema
+                    { yrke = yrke_
+                    , jobbTittel = info.jobbTittel
+                    , bedriftNavn = info.bedriftsnavn
+                    , lokasjon = info.sted
+                    , arbeidsoppgaver = info.arbeidsoppgaver
+                    , fraMåned = info.fraMåned
+                    , fraÅr = fraÅr_
+                    , tilDato = tilDato
+                    , id = info.id
+                    }
+            )
+            info.yrke
+            (validerTilDato info.nåværende info.tilMåned info.tilÅr)
+            (Dato.stringTilÅr info.fraÅr)
 
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -38,7 +38,7 @@ import Sprak.Seksjon
 import Task
 import Url
 import Utdanning.Seksjon
-import ValideringUtils as Validering
+import Validering
 
 
 

--- a/src/Utdanning/Seksjon.elm
+++ b/src/Utdanning/Seksjon.elm
@@ -35,7 +35,7 @@ import Process
 import SamtaleAnimasjon
 import Task
 import Utdanning.Skjema as Skjema exposing (Felt(..), UtdanningSkjema, ValidertUtdanningSkjema)
-import ValideringUtils as Validering
+import Validering
 
 
 

--- a/src/Utdanning/Skjema.elm
+++ b/src/Utdanning/Skjema.elm
@@ -31,7 +31,7 @@ module Utdanning.Skjema exposing
 import Cv.Utdanning as Utdanning exposing (Nivå(..), Utdanning)
 import Dato exposing (Måned(..), TilDato(..), År)
 import Json.Encode
-import ValideringUtils as Validering
+import Validering
 
 
 type UtdanningSkjema

--- a/src/Utdanning/Skjema.elm
+++ b/src/Utdanning/Skjema.elm
@@ -31,6 +31,7 @@ module Utdanning.Skjema exposing
 import Cv.Utdanning as Utdanning exposing (Nivå(..), Utdanning)
 import Dato exposing (Måned(..), TilDato(..), År)
 import Json.Encode
+import ValideringUtils as Validering
 
 
 type UtdanningSkjema
@@ -288,21 +289,25 @@ type alias ValidertUtdanningSkjemaInfo =
 
 validerSkjema : UtdanningSkjema -> Maybe ValidertUtdanningSkjema
 validerSkjema (UtdanningSkjema info) =
-    Maybe.map2
-        (\tilDato fraÅr ->
-            ValidertSkjema
-                { nivå = info.nivå
-                , studiested = info.studiested
-                , utdanningsretning = info.utdanningsretning
-                , beskrivelse = String.trim info.beskrivelse
-                , fraMåned = info.fraMåned
-                , fraÅr = fraÅr
-                , id = info.id
-                , tilDato = tilDato
-                }
-        )
-        (validerTilDato info.nåværende info.tilMåned info.tilÅr)
-        (Dato.stringTilÅr info.fraÅr)
+    if Validering.feilmeldingMaxAntallTegn info.beskrivelse 2000 /= Nothing then
+        Nothing
+
+    else
+        Maybe.map2
+            (\tilDato fraÅr ->
+                ValidertSkjema
+                    { nivå = info.nivå
+                    , studiested = info.studiested
+                    , utdanningsretning = info.utdanningsretning
+                    , beskrivelse = String.trim info.beskrivelse
+                    , fraMåned = info.fraMåned
+                    , fraÅr = fraÅr
+                    , id = info.id
+                    , tilDato = tilDato
+                    }
+            )
+            (validerTilDato info.nåværende info.tilMåned info.tilÅr)
+            (Dato.stringTilÅr info.fraÅr)
 
 
 validerTilDato : Bool -> Måned -> String -> Maybe TilDato

--- a/src/Validering.elm
+++ b/src/Validering.elm
@@ -1,4 +1,4 @@
-module ValideringUtils exposing (feilmeldingMaxAntallTegn)
+module Validering exposing (feilmeldingMaxAntallTegn)
 
 
 feilmeldingMaxAntallTegn : String -> Int -> Maybe String

--- a/src/ValideringUtils.elm
+++ b/src/ValideringUtils.elm
@@ -1,0 +1,15 @@
+module ValideringUtils exposing (feilmeldingMaxAntallTegn)
+
+
+feilmeldingMaxAntallTegn : String -> Int -> Maybe String
+feilmeldingMaxAntallTegn innhold lengde =
+    if String.length innhold <= lengde then
+        Nothing
+
+    else
+        let
+            tallTekst =
+                (String.length innhold - lengde)
+                    |> String.fromInt
+        in
+        Just ("Du har " ++ tallTekst ++ " tegn for mye")


### PR DESCRIPTION
Validerer max lengde på beskrivelse av utdanning, arbeidsoppgaver i arbeidserfaring og sammendrag.

Har brukt samme grenser som i vanlig cv. 