### PR TITLE
Småfikser på mobil

### DIFF
--- a/src/FrontendModuler/Header.elm
+++ b/src/FrontendModuler/Header.elm
@@ -30,14 +30,14 @@ toHtml (Header options) =
             [ a [ href "/", ariaLabel "Logo Arbeidsplassen" ]
                 [ arbeidsplassenLogo ]
             ]
-
-        -- TODO: Endre til å vise burger-meny på mobil og evt. iPad
         , if options.windowWidth > 460 then
             button
-                [ class "Knapp Knapp--flat"
+                [ class "Knapp Knapp--flat avslutt-knapp-med-ikon"
                 , onClick options.onClickMsg
                 ]
-                [ text "Avslutt CV-registreringen" ]
+                [ text "Avslutt CV-registreringen"
+                , i [ class "avslutt-ikon" ] []
+                ]
 
           else
             button

--- a/src/styles.less
+++ b/src/styles.less
@@ -47,21 +47,26 @@ html {
     padding-left: 1.25rem;
     padding-right: 1.25rem;
   }
-  @media (max-width: 767px) {
-    padding-right: 1.25rem;
-  }
+
 
   .avslutt-knapp-med-ikon {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
     align-items: center;
+
+    @media (max-width: 460px) {
+      flex-direction: column;
+      justify-content: center;
+    }
 
     .avslutt-ikon {
       height: 25px;
       width: 25px;
       margin-bottom: 2px;
       background-image: data-uri('image/svg+xml;charset=UTF-8', '../assets/Avslutt.svg');
+
+      @media(min-width: 461px) {
+          margin-left: 0.5rem;
+      }
     }
   }
 
@@ -816,5 +821,23 @@ html {
 
   .gi-tilbakemelding-lenke {
     font-weight: 600;
+  }
+
+
+  @media (max-width: 671px) {
+
+    h2 {
+      font-size: 1.375rem;
+      margin-right: 1.25rem;
+    }
+
+    section {
+      display:flex;
+      flex-direction: column;
+
+      a:first-child {
+        margin: 0 0 1rem;
+      }
+    }
   }
 }


### PR DESCRIPTION
- mindre padding på høyre side av avsluttknapp
- gjør plass til overskrift i modal på mobil, ved gjøre den mindre og legge til margin
- lar lenker i modal ligge under hverandre

Legger også til ikon på avslutt-knapp desktop