### PR TITLE
PAM-3924 Tekstendring i arbeidserfaring, alternativ tittel

### DIFF
--- a/src/Arbeidserfaring/Seksjon.elm
+++ b/src/Arbeidserfaring/Seksjon.elm
@@ -127,7 +127,7 @@ type Msg
     | FeltMisterFokus
     | TimeoutEtterAtFeltMistetFokus
     | BrukerVilRegistrereYrke
-    | BrukerVilEndreJobbtittel JobbtittelInfo
+    | BrukerVilEndreJobbtittel
     | BrukerVilIkkeEndreJobbtittel
     | BrukerOppdatererJobbtittelFelt String
     | BrukerVilRegistrereJobbtittel
@@ -470,13 +470,18 @@ update msg (Model model) =
                 _ ->
                     IkkeFerdig ( Model model, Cmd.none )
 
-        BrukerVilEndreJobbtittel jobbtittelInfo ->
-            ( jobbtittelInfo
-                |> EndreJobbtittel
-                |> oppdaterSamtale model (SvarFraMsg msg)
-            , lagtTilSpørsmålCmd model.debugStatus
-            )
-                |> IkkeFerdig
+        BrukerVilEndreJobbtittel ->
+            case model.aktivSamtale of
+                SpørOmBrukerVilEndreJobbtittel jobbtittelInfo ->
+                    ( jobbtittelInfo
+                        |> EndreJobbtittel
+                        |> oppdaterSamtale model (SvarFraMsg msg)
+                    , lagtTilSpørsmålCmd model.debugStatus
+                    )
+                        |> IkkeFerdig
+
+                _ ->
+                    IkkeFerdig ( Model model, Cmd.none )
 
         BrukerOppdatererJobbtittelFelt string ->
             case model.aktivSamtale of
@@ -1405,7 +1410,7 @@ samtaleTilMeldingsLogg personaliaSeksjon =
                     ]
 
         SpørOmBrukerVilEndreJobbtittel info ->
-            [ Melding.spørsmål [ "Du valgte «" ++ Yrke.label info.tidligereInfo ++ "» . Hvis dette ikke stemmer helt, kan du gi yrket et nytt navn. Det navnet vil vises på CV-en din. Ønsker du å kalle det noe annet? " ]
+            [ Melding.spørsmål [ "Du valgte «" ++ Yrke.label info.tidligereInfo ++ "». Hvis dette ikke stemmer helt, kan du gi yrket et nytt navn. Det navnet vil vises på CV-en din. Vil du gi det et nytt navn?" ]
             ]
 
         EndreJobbtittel _ ->
@@ -1614,11 +1619,11 @@ modelTilBrukerInput model =
             RegistrerYrke _ visFeilmelding typeaheadModel ->
                 viewRegistrerYrke visFeilmelding typeaheadModel
 
-            SpørOmBrukerVilEndreJobbtittel jobbtittelInfo ->
+            SpørOmBrukerVilEndreJobbtittel _ ->
                 BrukerInput.knapper Flytende
-                    [ Knapp.knapp BrukerVilIkkeEndreJobbtittel "Nei, jeg vil ikke kalle det noe annet"
+                    [ Knapp.knapp BrukerVilEndreJobbtittel "Ja, jeg vil gi det et nytt navn"
                         |> Knapp.withId (inputIdTilString EndreJobbtittelId)
-                    , Knapp.knapp (BrukerVilEndreJobbtittel jobbtittelInfo) "Ja, jeg vil kalle det noe annet"
+                    , Knapp.knapp BrukerVilIkkeEndreJobbtittel "Nei, gå videre"
                     ]
 
             EndreJobbtittel jobbtittelInfo ->


### PR DESCRIPTION
Jira: https://jira.adeo.no/browse/PAM-3924

> # Brukerhistorie
> 
> ## Beskrivelse
> Det ser ut som at en del brukere trykker på feil knapp når de får valg om å endre navn på et yrke. Jeg har en teori om at det er fordi ordlyden på knappene forvirrer. 
> Flyt: https://zpl.io/251wAAr 
> 
> ## Original tekst: 
> "Du valgte {stilling/yrke}. Hvis dette ikke stemmer helt, kan du gi yrket et nytt navn. Det navnet vil vises på CV-en din. Ønsker du å kalle det noe annet?"
> 
> Knapp 1 = "Nei, jeg vil ikke kalle det noe annet"
> Knapp 2 = "Ja, jeg vil kalle det noe annet"
> 
> ## Ny tekst:
> "Du valgte {stilling/yrke}. Hvis dette ikke stemmer helt, kan du gi yrket et nytt navn. Det navnet vil vises på CV-en din. Vil du gi det et nytt navn?"
> 
> Knapp 1 = "Ja, jeg vil gi det et nytt navn"
> Knapp 2 = "Nei, gå videre"